### PR TITLE
Fix credential assignment dialog and badges

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
 import {
   Dialog,
   DialogContent,
@@ -93,14 +94,6 @@ export default function Home() {
     setSelectedUser(null)
     setSelectedCredId("")
     setValueFields({})
-  }
-
-  const assignedCredentialNames = (userId: string) => {
-    const arr = assignments[userId] || []
-    return arr
-      .map((a) => credentials.find((c) => c.id === a.credentialId)?.name ?? "")
-      .filter(Boolean)
-      .join(", ")
   }
 
   const credentialAssignedCount = (credId: string) => {
@@ -204,14 +197,47 @@ export default function Home() {
             {users.map((user) => (
               <TableRow key={user.id}>
                 <TableCell>{user.name}</TableCell>
-                <TableCell>{assignedCredentialNames(user.id)}</TableCell>
+                <TableCell className="space-x-1">
+                  {assignments[user.id]?.map((a, idx) => {
+                    const cred = credentials.find((c) => c.id === a.credentialId)
+                    if (!cred) return null
+                    return (
+                      <Dialog key={idx}>
+                        <DialogTrigger asChild>
+                          <Badge variant="secondary" className="cursor-pointer">
+                            {cred.name}
+                          </Badge>
+                        </DialogTrigger>
+                        <DialogContent className="space-y-2">
+                          <DialogHeader>
+                            <DialogTitle>{cred.name}</DialogTitle>
+                          </DialogHeader>
+                          {cred.properties.map((p) => (
+                            <div key={p} className="text-sm">
+                              <span className="font-medium mr-1">{p}:</span>
+                              {a.values[p]}
+                            </div>
+                          ))}
+                        </DialogContent>
+                      </Dialog>
+                    )
+                  })}
+                </TableCell>
                 <TableCell className="text-right">
                   <Dialog
                     open={selectedUser?.id === user.id}
-                    onOpenChange={(open) => !open && setSelectedUser(null)}
+                    onOpenChange={(open) => {
+                      if (open) {
+                        setSelectedUser(user)
+                      } else {
+                        setSelectedUser(null)
+                        setSelectedCredId("")
+                        setValueFields({})
+                      }
+                    }}
                   >
                     <DialogTrigger asChild>
-                      <Button size="sm">Assign credential</Button>
+                      <Button size="sm">Add credential</Button>
                     </DialogTrigger>
                     <DialogContent className="space-y-4">
                       <DialogHeader>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## Summary
- add Badge component from shadcn
- open assign dialog properly when clicking add credential
- show assigned credentials as clickable badges

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dbed0ece48328bb629aa2a2986cc4