### PR TITLE
Fix comma entry for select options

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -180,8 +180,7 @@ export default function Home() {
                         updateProp(idx, {
                           options: e.target.value
                             .split(/,/)
-                            .map((o) => o.trim())
-                            .filter(Boolean),
+                            .map((o) => o.trim()),
                         })
                       }
                     />


### PR DESCRIPTION
## Summary
- allow commas when entering select option values

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e88869ce48328843a1b864c17b287