### PR TITLE
Fix backspace behavior in select options input

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -180,7 +180,8 @@ export default function Home() {
                         updateProp(idx, {
                           options: e.target.value
                             .split(/,/)
-                            .map((o) => o.trim()),
+                            .map((o) => o.trim())
+                            .filter(Boolean),
                         })
                       }
                     />


### PR DESCRIPTION
## Summary
- trim blank option entries when typing option lists so backspace can remove commas normally

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ec59a157083288a69034e46d4aa64