### PR TITLE
Improve calendar year selection

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -15,7 +15,7 @@ function Calendar({
   className,
   classNames,
   showOutsideDays = true,
-  captionLayout = "label",
+  captionLayout = "dropdown",
   buttonVariant = "ghost",
   formatters,
   components,


### PR DESCRIPTION
## Summary
- improve Calendar default to use dropdown caption for easier year selection

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ed2b86fc4832888a05feaa0fe16ea